### PR TITLE
サポートしないShapeTypeがあった時に例外を投げる

### DIFF
--- a/lib/thinreports/section_report/pdf/renderer/draw_item.rb
+++ b/lib/thinreports/section_report/pdf/renderer/draw_item.rb
@@ -57,7 +57,7 @@ module Thinreports
           elsif shape.type_of?(Core::Shape::StackView::TYPE_NAME)
             stack_view_renderer.render(shape)
           else
-            puts 'unknown shape type'
+            raise Thinreports::Errors::UnknownShapeType
           end
         end
       end

--- a/lib/thinreports/section_report/pdf/renderer/stack_view_row_renderer.rb
+++ b/lib/thinreports/section_report/pdf/renderer/stack_view_row_renderer.rb
@@ -30,7 +30,7 @@ module Thinreports
         attr_reader :pdf
 
         def stack_view_renderer
-          @stack_view_renderer ||= Renderer::StackViewRenderer.new(pdf)
+          raise Thinreports::Errors::InvalidLayoutFormat, 'nested StackView does not supported'
         end
       end
     end


### PR DESCRIPTION
以下の状況で、例外を投げるようにします
- StackViewが入れ子になっていたとき
- draw_itemで意図しないShapeTypeがあったとき

## 動作確認

> StackViewが入れ子になっていたとき

`test/features/stack_view/template.tlf` のStackViewの中に、以下のitemを追加してテストを実行し、例外 `Thinreports::Errors::InvalidLayoutFormat: nested StackView does not supported
` が発生するのを確認した。

```
                {
                  "id": "stack_view_nested",
                  "type": "stack-view",
                  "x": 0,
                  "y": 0,
                  "width": 10,
                  "display": true,
                  "rows": [
                  ]
                },
```

> draw_itemで意図しないShapeTypeがあったとき

通常このパスを通ることは無いと思う（別の場所で例外が発生する）。
draw_itemの最後のelsif節を消してテストを実行し、例外 `Thinreports::Errors::UnknownShapeType: Thinreports::Errors::UnknownShapeType` が発生することを確認した。