### PR TITLE
section_report_content_type_float example を追加

### DIFF
--- a/test/features/section_report_content_type_float/README.md
+++ b/test/features/section_report_content_type_float/README.md
@@ -1,0 +1,14 @@
+# ContentType Float
+
+要素の種類が `float` である item を、stack-view の row に配置すると、item を row から下にはみ出させることができる。
+
+- [Example code](test_section_report_content_type_float.rb)
+- [Example template file](template.tlf)
+- [Example PDF](expect.pdf)
+
+要素の種類が `float` である item は、下余白の計算には影響するが、コンテンツの下位置の計算では無視される。
+このため、要素の種類が `float` である item は、row から下にはみ出す場合がある。
+
+要素の種類が `float` である item が、row を積み重ねた高さよりも下にはみ出す場合には、stack-view の高さがその分拡張する。
+
+row の伸縮の仕様は、[StackViewRow Auto Stretch](../section_report_stack_view_row_auto_stretch/README.md) を参照。

--- a/test/features/section_report_content_type_float/expect.pdf
+++ b/test/features/section_report_content_type_float/expect.pdf
@@ -1,0 +1,433 @@
+%PDF-1.3
+%ÿÿÿÿ
+1 0 obj
+<< /CreationDate (D:20200601082647+00'00')
+/Creator <feff005400680069006e007200650070006f007200740073002000470065006e0065007200610074006f007200200066006f00720020005200750062007900200030002e00310030002e0033>
+/Title null
+/Producer <feff0050007200610077006e>
+>>
+endobj
+2 0 obj
+<< /Type /Catalog
+/Pages 3 0 R
+>>
+endobj
+3 0 obj
+<< /Type /Pages
+/Count 1
+/Kids [7 0 R]
+>>
+endobj
+4 0 obj
+<< /Length 8
+>>
+stream
+q
+0.9 w
+
+endstream
+endobj
+5 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 612.0 792.0]
+/CropBox [0 0 612.0 792.0]
+/BleedBox [0 0 612.0 792.0]
+/TrimBox [0 0 612.0 792.0]
+/ArtBox [0 0 612.0 792.0]
+/Contents 4 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+>>
+>>
+endobj
+6 0 obj
+<< /Length 3228
+>>
+stream
+q
+0.9 w
+q
+/DeviceRGB cs
+0.0 0.0 0.0 scn
+Q
+q
+/DeviceRGB cs
+0.0 0.0 0.0 scn
+Q
+q
+/DeviceRGB cs
+0.0 0.0 0.0 scn
+Q
+q
+/DeviceRGB cs
+0.0 0.0 0.0 scn
+Q
+q
+0.9 w
+/DeviceRGB CS
+0.0 0.0 0.0 SCN
+0.0 821.89 m
+595.28 821.89 l
+S
+Q
+q
+/DeviceRGB cs
+0.0 0.0 0.0 scn
+Q
+q
+/DeviceRGB cs
+0.0 0.0 0.0 scn
+Q
+q
+/DeviceRGB cs
+0.0 0.0 0.0 scn
+Q
+q
+0.9 w
+/DeviceRGB CS
+0.0 0.0 0.0 SCN
+20.0 791.89 m
+520.0 791.89 l
+S
+Q
+q
+/DeviceRGB cs
+0.0 0.0 0.0 scn
+Q
+q
+/DeviceRGB cs
+0.0 0.0 0.0 scn
+
+BT
+60.0 748.966 Td
+/F1.0 18 Tf
+[<6c6f6e67206c6f6e67>] TJ
+ET
+
+
+BT
+60.0 729.166 Td
+/F1.0 18 Tf
+[<6c6f6e67206c6f6e67>] TJ
+ET
+
+
+BT
+60.0 709.366 Td
+/F1.0 18 Tf
+[<6c6f6e67206c6f6e67>] TJ
+ET
+
+
+BT
+60.0 689.566 Td
+/F1.0 18 Tf
+[<6c6f6e67206c6f6e67>] TJ
+ET
+
+
+BT
+60.0 669.766 Td
+/F1.0 18 Tf
+[<6c6f6e67206c6f6e67>] TJ
+ET
+
+
+BT
+60.0 649.966 Td
+/F1.0 18 Tf
+[<6c6f6e67206c6f6e67>] TJ
+ET
+
+
+BT
+60.0 630.166 Td
+/F1.0 18 Tf
+[<6c6f6e67206c6f6e67>] TJ
+ET
+
+
+BT
+60.0 610.366 Td
+/F1.0 18 Tf
+[<6c6f6e67206c6f6e67>] TJ
+ET
+
+
+BT
+60.0 590.566 Td
+/F1.0 18 Tf
+[<6c6f6e67206c6f6e67>] TJ
+ET
+
+
+BT
+60.0 570.766 Td
+/F1.0 18 Tf
+[<6c6f6e67207465> 30 <7874>] TJ
+ET
+
+Q
+q
+[2.0 2.0] 0.0 d
+0.9 w
+/DeviceRGB cs
+1.0 1.0 1.0 scn
+/DeviceRGB CS
+0.0 0.0 0.0 SCN
+220.0 621.89 170.0 150.0 re
+b
+Q
+q
+/DeviceRGB cs
+0.0 0.0 0.0 scn
+
+BT
+230.0 748.966 Td
+/F1.0 18 Tf
+[<636f6e74656e742d747970653a> 50 <a0666c6f6174>] TJ
+ET
+
+Q
+q
+/DeviceRGB cs
+0.6667 0.6667 0.6667 scn
+
+BT
+484.176 780.274 Td
+/F1.0 12 Tf
+[<726f> 15 <7731>] TJ
+ET
+
+Q
+q
+0.9 w
+/DeviceRGB CS
+0.0 0.0 0.0 SCN
+20.0 543.89 m
+520.0 543.89 l
+S
+Q
+q
+/DeviceRGB cs
+0.6667 0.6667 0.6667 scn
+
+BT
+433.692 532.274 Td
+/F1.0 12 Tf
+[<726f> 15 <7732a02864756d6d> 15 <7929>] TJ
+ET
+
+Q
+q
+/DeviceRGB cs
+0.6667 0.6667 0.6667 scn
+
+BT
+556.32 810.274 Td
+/F1.0 12 Tf
+[<64657461696c>] TJ
+ET
+
+Q
+q
+/DeviceRGB cs
+0.0 0.0 0.0 scn
+Q
+q
+/DeviceRGB cs
+0.0 0.0 0.0 scn
+Q
+q
+/DeviceRGB cs
+0.0 0.0 0.0 scn
+Q
+q
+/DeviceRGB cs
+0.0 0.0 0.0 scn
+Q
+q
+/DeviceRGB cs
+0.0 0.0 0.0 scn
+Q
+q
+/DeviceRGB cs
+0.0 0.0 0.0 scn
+Q
+q
+0.9 w
+/DeviceRGB CS
+0.0 0.0 0.0 SCN
+0.0 513.89 m
+595.28 513.89 l
+S
+Q
+q
+/DeviceRGB cs
+0.0 0.0 0.0 scn
+Q
+q
+/DeviceRGB cs
+0.0 0.0 0.0 scn
+Q
+q
+/DeviceRGB cs
+0.0 0.0 0.0 scn
+Q
+q
+0.9 w
+/DeviceRGB CS
+0.0 0.0 0.0 SCN
+20.0 483.89 m
+520.0 483.89 l
+S
+Q
+q
+/DeviceRGB cs
+0.0 0.0 0.0 scn
+Q
+q
+/DeviceRGB cs
+0.0 0.0 0.0 scn
+
+BT
+60.0 440.966 Td
+/F1.0 18 Tf
+[<73686f72> -40 <74207465> 30 <7874>] TJ
+ET
+
+Q
+q
+[2.0 2.0] 0.0 d
+0.9 w
+/DeviceRGB cs
+1.0 1.0 1.0 scn
+/DeviceRGB CS
+0.0 0.0 0.0 SCN
+220.0 313.89 170.0 150.0 re
+b
+Q
+q
+/DeviceRGB cs
+0.0 0.0 0.0 scn
+
+BT
+230.0 440.966 Td
+/F1.0 18 Tf
+[<636f6e74656e742d747970653a> 50 <a0666c6f6174>] TJ
+ET
+
+Q
+q
+/DeviceRGB cs
+0.6667 0.6667 0.6667 scn
+
+BT
+484.176 472.274 Td
+/F1.0 12 Tf
+[<726f> 15 <7731>] TJ
+ET
+
+Q
+q
+0.9 w
+/DeviceRGB CS
+0.0 0.0 0.0 SCN
+20.0 413.89 m
+520.0 413.89 l
+S
+Q
+q
+/DeviceRGB cs
+0.6667 0.6667 0.6667 scn
+
+BT
+433.692 402.274 Td
+/F1.0 12 Tf
+[<726f> 15 <7732a02864756d6d> 15 <7929>] TJ
+ET
+
+Q
+q
+/DeviceRGB cs
+0.6667 0.6667 0.6667 scn
+
+BT
+556.32 502.274 Td
+/F1.0 12 Tf
+[<64657461696c>] TJ
+ET
+
+Q
+q
+/DeviceRGB cs
+0.0 0.0 0.0 scn
+Q
+q
+/DeviceRGB cs
+0.0 0.0 0.0 scn
+Q
+q
+0.9 w
+/DeviceRGB CS
+0.0 0.0 0.0 SCN
+0.0 303.89 m
+595.28 303.89 l
+S
+Q
+q
+/DeviceRGB cs
+0.6667 0.6667 0.6667 scn
+
+BT
+504.192 292.274 Td
+/F1.0 12 Tf
+[<66> 30 <6f6f746572a02864756d6d> 15 <7929>] TJ
+ET
+
+Q
+Q
+
+endstream
+endobj
+7 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 6 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F1.0 8 0 R
+>>
+>>
+>>
+endobj
+8 0 obj
+<< /Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000015 00000 n 
+0000000289 00000 n 
+0000000338 00000 n 
+0000000395 00000 n 
+0000000452 00000 n 
+0000000714 00000 n 
+0000003994 00000 n 
+0000004290 00000 n 
+trailer
+<< /Size 9
+/Root 2 0 R
+/Info 1 0 R
+>>
+startxref
+4387
+%%EOF

--- a/test/features/section_report_content_type_float/template.tlf
+++ b/test/features/section_report_content_type_float/template.tlf
@@ -1,0 +1,329 @@
+{
+  "schema-version": "1.0",
+  "last-modified-by": "1.0.0-alpha.4",
+  "title": "",
+  "report": {
+    "orientation": "portrait",
+    "paper-type": "A4",
+    "width": 0,
+    "height": 0,
+    "margin": [
+      20,
+      20,
+      20,
+      20
+    ]
+  },
+  "sections": [
+    {
+      "id": "detail",
+      "type": "detail",
+      "height": 250,
+      "auto-stretch": true,
+      "items": [
+        {
+          "type": "line",
+          "id": "",
+          "x1": 0,
+          "y1": 0,
+          "x2": 595.28,
+          "y2": 0,
+          "description": "",
+          "display": true,
+          "follow-stretch": "none",
+          "content-type": "content",
+          "style": {
+            "border-width": 1,
+            "border-color": "#000000",
+            "border-style": "solid"
+          }
+        },
+        {
+          "type": "stack-view",
+          "id": "stackview",
+          "x": 20,
+          "y": 30,
+          "width": 500,
+          "description": "",
+          "display": true,
+          "content-type": "content",
+          "follow-stretch": "none",
+          "rows": [
+            {
+              "id": "row1",
+              "height": 190,
+              "auto-stretch": true,
+              "display": true,
+              "items": [
+                {
+                  "type": "line",
+                  "id": "",
+                  "x1": 0,
+                  "y1": 0,
+                  "x2": 500,
+                  "y2": 0,
+                  "description": "",
+                  "display": true,
+                  "follow-stretch": "none",
+                  "content-type": "content",
+                  "style": {
+                    "border-width": 1,
+                    "border-color": "#000000",
+                    "border-style": "solid"
+                  }
+                },
+                {
+                  "type": "text-block",
+                  "id": "textblock",
+                  "x": 40,
+                  "y": 30,
+                  "width": 100,
+                  "height": 20,
+                  "description": "",
+                  "reference-id": "",
+                  "value": "",
+                  "multiple-line": true,
+                  "display": true,
+                  "format": {
+                    "base": "",
+                    "type": ""
+                  },
+                  "follow-stretch": "none",
+                  "content-type": "content",
+                  "style": {
+                    "font-family": [
+                      "Helvetica"
+                    ],
+                    "color": "#000000",
+                    "font-style": [],
+                    "text-align": "left",
+                    "vertical-align": "top",
+                    "letter-spacing": "",
+                    "overflow": "expand",
+                    "word-wrap": "break-word",
+                    "font-size": 18,
+                    "line-height-ratio": "",
+                    "line-height": 19.8
+                  }
+                },
+                {
+                  "type": "rect",
+                  "id": "",
+                  "x": 200,
+                  "y": 20,
+                  "width": 170,
+                  "height": 150,
+                  "border-radius": 0,
+                  "description": "",
+                  "display": true,
+                  "follow-stretch": "none",
+                  "content-type": "float",
+                  "style": {
+                    "border-color": "#000000",
+                    "border-style": "dashed",
+                    "fill-color": "#ffffff",
+                    "border-width": 1
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "",
+                  "x": 210,
+                  "y": 30,
+                  "width": 150,
+                  "height": 20,
+                  "description": "",
+                  "display": true,
+                  "follow-stretch": "none",
+                  "content-type": "background",
+                  "texts": [
+                    "content-type: float"
+                  ],
+                  "style": {
+                    "font-family": [
+                      "Helvetica"
+                    ],
+                    "color": "#000000",
+                    "font-style": [],
+                    "text-align": "left",
+                    "vertical-align": "top",
+                    "letter-spacing": "",
+                    "font-size": 18,
+                    "line-height-ratio": "",
+                    "line-height": 19.8
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "",
+                  "x": 400,
+                  "y": 3,
+                  "width": 90,
+                  "height": 15,
+                  "description": "",
+                  "display": true,
+                  "follow-stretch": "none",
+                  "content-type": "content",
+                  "texts": [
+                    "row1"
+                  ],
+                  "style": {
+                    "font-family": [
+                      "Helvetica"
+                    ],
+                    "color": "#aaaaaa",
+                    "font-style": [],
+                    "text-align": "right",
+                    "vertical-align": "top",
+                    "letter-spacing": "",
+                    "font-size": 12,
+                    "line-height-ratio": "",
+                    "line-height": 13.2
+                  }
+                }
+              ]
+            },
+            {
+              "id": "row2",
+              "height": 20,
+              "auto-stretch": false,
+              "display": true,
+              "items": [
+                {
+                  "type": "line",
+                  "id": "",
+                  "x1": 0,
+                  "y1": 0,
+                  "x2": 500,
+                  "y2": 0,
+                  "description": "",
+                  "display": true,
+                  "follow-stretch": "none",
+                  "content-type": "content",
+                  "style": {
+                    "border-width": 1,
+                    "border-color": "#000000",
+                    "border-style": "solid"
+                  }
+                },
+                {
+                  "type": "text",
+                  "id": "",
+                  "x": 400,
+                  "y": 3,
+                  "width": 90,
+                  "height": 15,
+                  "description": "",
+                  "display": true,
+                  "follow-stretch": "none",
+                  "content-type": "content",
+                  "texts": [
+                    "row2 (dummy)"
+                  ],
+                  "style": {
+                    "font-family": [
+                      "Helvetica"
+                    ],
+                    "color": "#aaaaaa",
+                    "font-style": [],
+                    "text-align": "right",
+                    "vertical-align": "top",
+                    "letter-spacing": "",
+                    "font-size": 12,
+                    "line-height-ratio": "",
+                    "line-height": 13.2
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "id": "",
+          "x": 495,
+          "y": 3,
+          "width": 90,
+          "height": 15,
+          "description": "",
+          "display": true,
+          "follow-stretch": "none",
+          "content-type": "content",
+          "texts": [
+            "detail"
+          ],
+          "style": {
+            "font-family": [
+              "Helvetica"
+            ],
+            "color": "#aaaaaa",
+            "font-style": [],
+            "text-align": "right",
+            "vertical-align": "top",
+            "letter-spacing": "",
+            "font-size": 12,
+            "line-height-ratio": "",
+            "line-height": 13.2
+          }
+        }
+      ]
+    },
+    {
+      "id": "fotter",
+      "type": "footer",
+      "height": 20,
+      "display": true,
+      "auto-stretch": false,
+      "items": [
+        {
+          "type": "line",
+          "id": "",
+          "x1": 0,
+          "y1": 0,
+          "x2": 595.28,
+          "y2": 0,
+          "description": "",
+          "display": true,
+          "follow-stretch": "none",
+          "content-type": "content",
+          "style": {
+            "border-width": 1,
+            "border-color": "#000000",
+            "border-style": "solid"
+          }
+        },
+        {
+          "type": "text",
+          "id": "",
+          "x": 495,
+          "y": 3,
+          "width": 90,
+          "height": 15,
+          "description": "",
+          "display": true,
+          "follow-stretch": "none",
+          "content-type": "content",
+          "texts": [
+            "footer (dummy)"
+          ],
+          "style": {
+            "font-family": [
+              "Helvetica"
+            ],
+            "color": "#aaaaaa",
+            "font-style": [],
+            "text-align": "right",
+            "vertical-align": "top",
+            "letter-spacing": "",
+            "font-size": 12,
+            "line-height-ratio": "",
+            "line-height": 13.2
+          }
+        }
+      ]
+    }
+  ],
+  "state": {
+    "layout-guides": []
+  }
+}

--- a/test/features/section_report_content_type_float/test_section_report_content_type_float.rb
+++ b/test/features/section_report_content_type_float/test_section_report_content_type_float.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'feature_test'
+
+class TestSectionReportContentTypeFloat < FeatureTest
+  feature :section_report_content_type_float do
+    params = {
+      type: :section,
+      layout_file: template_path,
+      params: {
+        groups: [
+          {
+            details: [
+              {
+                id: 'detail',
+                items: {
+                  stackview: {
+                    rows: {
+                      row1: {
+                        items: {
+                          textblock: 'long ' * 19 + 'text'
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                id: 'detail',
+                items: {
+                  stackview: {
+                    rows: {
+                      row1: {
+                        items: {
+                          textblock: 'short text'
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+    assert_pdf Thinreports.generate(params)
+  end
+
+  def image50x50
+    StringIO.new(dir.join('50x50.jpg').binread)
+  end
+end
+
+

--- a/test/features/section_report_section_auto_stretch/README.md
+++ b/test/features/section_report_section_auto_stretch/README.md
@@ -13,7 +13,7 @@
 section の伸縮後の高さは「下余白」と「コンテンツの下位置」によって決定する。
 
 コンテンツの下位置
-- section 内の item の最下部の位置を指す (要素の種類が `background` の item は除外)
+- section 内の item の最下部の位置を指す (要素の種類が `background` または `float` の item は除外)
 - 描画結果によって変動する
 
 下余白


### PR DESCRIPTION
section_report_section_auto_stretch の README のコンテンツの下位置の説明も少し修正してある。