### PR TITLE
自動伸縮OFFの時に、min_heightでsectionの高さを修正できる仕様を削除

### DIFF
--- a/lib/thinreports/section_report/pdf/renderer/section_height.rb
+++ b/lib/thinreports/section_report/pdf/renderer/section_height.rb
@@ -7,7 +7,7 @@ module Thinreports
         LayoutInfo = Struct.new(:shape, :content_height, :top_margin, :bottom_margin)
 
         def section_height(section)
-          return (section.min_height || section.schema.height) unless section.schema.auto_stretch?
+          return section.schema.height unless section.schema.auto_stretch?
 
           item_layouts = section.items.map { |item| item_layout(section, item.internal) }.compact
 

--- a/lib/thinreports/section_report/pdf/renderer/section_height.rb
+++ b/lib/thinreports/section_report/pdf/renderer/section_height.rb
@@ -7,7 +7,7 @@ module Thinreports
         LayoutInfo = Struct.new(:shape, :content_height, :top_margin, :bottom_margin)
 
         def section_height(section)
-          return (section.min_height || section.schema.height) unless section.schema.auto_stretch? && section.items
+          return (section.min_height || section.schema.height) unless section.schema.auto_stretch?
 
           item_layouts = section.items.map { |item| item_layout(section, item.internal) }.compact
 


### PR DESCRIPTION
refactoringも含んでいます https://github.com/standfirm/thinreports-generator/pull/66/commits/168c3628909206429ee13b818d814c997cf649a0