### PR TITLE
example の空のパラメータ指定を削除

### DIFF
--- a/lib/thinreports/section_report/builder/report_builder.rb
+++ b/lib/thinreports/section_report/builder/report_builder.rb
@@ -14,7 +14,6 @@ module Thinreports
         def build(params)
           ReportData::Main.new(
             schema,
-            params[:start_page_number] || 1,
             build_groups(params[:groups])
           )
         end

--- a/lib/thinreports/section_report/builder/report_data.rb
+++ b/lib/thinreports/section_report/builder/report_data.rb
@@ -4,7 +4,7 @@ module Thinreports
   module SectionReport
     module Builder
       module ReportData
-        Main = Struct.new :schema, :start_page_number, :groups
+        Main = Struct.new :schema, :groups
         Group = Struct.new :headers, :details, :footers
         Section = Struct.new :schema, :items, :min_height
       end

--- a/test/features/section_report/test_section_report.rb
+++ b/test/features/section_report/test_section_report.rb
@@ -8,7 +8,6 @@ class TestSectionReport < FeatureTest
       type: :section,
       layout_file: template_path,
       params: {
-        start_page_number: 1,
         groups: [
           {
             headers: {

--- a/test/features/section_report_basic/README.md
+++ b/test/features/section_report_basic/README.md
@@ -42,7 +42,13 @@ params = {
   params: {
     groups: [
       {
-        headers: {},
+        headers: {
+          any_header_id: {
+            items: {
+              logo_image: '/path/to/logo.jpg'
+            }
+          }
+        },
         details: [
           {
             id: 'detail_id',
@@ -69,4 +75,3 @@ PDF データを取得する場合は `filename` を省略する。
 ```ruby
 Thinreports.generate(params) #=> PDF data
 ```
-

--- a/test/features/section_report_basic/test_section_report_basic.rb
+++ b/test/features/section_report_basic/test_section_report_basic.rb
@@ -14,7 +14,6 @@ class TestSectionReportBasic < FeatureTest
       params: {
         groups: [
           {
-            headers: {},
             details: build_details,
             footers: {
               overall: {

--- a/test/features/section_report_basic/test_section_report_basic.rb
+++ b/test/features/section_report_basic/test_section_report_basic.rb
@@ -81,6 +81,3 @@ class TestSectionReportBasic < FeatureTest
     ]
   end
 end
-
-
-

--- a/test/features/section_report_follow_stretch_height/test_follow_stretch_height.rb
+++ b/test/features/section_report_follow_stretch_height/test_follow_stretch_height.rb
@@ -8,7 +8,6 @@ class TestSectionReportFollowStretchHeight < FeatureTest
       type: :section,
       layout_file: template_path,
       params: {
-        start_page_number: 1,
         groups: [
           {
             details: [

--- a/test/features/section_report_item_follow_stretch/test_section_report_item_follow_stretch.rb
+++ b/test/features/section_report_item_follow_stretch/test_section_report_item_follow_stretch.rb
@@ -8,7 +8,6 @@ class TestSectionReportItemFollowStretch < FeatureTest
       type: :section,
       layout_file: template_path,
       params: {
-        start_page_number: 1,
         groups: [
           {
             headers: {

--- a/test/features/section_report_item_parameters/test_section_report_item_parameters.rb
+++ b/test/features/section_report_item_parameters/test_section_report_item_parameters.rb
@@ -14,8 +14,7 @@ class TestSectionReportItemParameters < FeatureTest
               {
                 id: :detail1,
                 items: {
-                  image_block: image_block_jpg.to_path,
-                  stackview: {}
+                  image_block: image_block_jpg.to_path
                 }
               },
               {
@@ -45,8 +44,7 @@ class TestSectionReportItemParameters < FeatureTest
                       linethrough: false
                     }
                   },
-                  image_block: image_block_jpg.to_path,
-                  stackview: {}
+                  image_block: image_block_jpg.to_path
                 }
               },
               {
@@ -58,8 +56,7 @@ class TestSectionReportItemParameters < FeatureTest
                       offset_x: 20,
                       offset_y: -20
                     }
-                  },
-                  stackview: {}
+                  }
                 }
               },
               {

--- a/test/features/section_report_multiple_groups/test_section_report_multiple_groups.rb
+++ b/test/features/section_report_multiple_groups/test_section_report_multiple_groups.rb
@@ -8,7 +8,6 @@ class TestSectionReportMultipleGroups < FeatureTest
       type: :section,
       layout_file: template_path,
       params: {
-        start_page_number: 1,
         groups: [
           {
             headers: {

--- a/test/features/section_report_section_bottom_margin/test_section_report_section_bottom_margin.rb
+++ b/test/features/section_report_section_bottom_margin/test_section_report_section_bottom_margin.rb
@@ -8,7 +8,6 @@ class TestSectionReportSectionBottomMargin < FeatureTest
       type: :section,
       layout_file: template_path,
       params: {
-        start_page_number: 1,
         groups: [
           {
             details: [

--- a/test/features/section_report_stack_view/test_section_report_stack_view.rb
+++ b/test/features/section_report_stack_view/test_section_report_stack_view.rb
@@ -8,7 +8,6 @@ class TestSectionReportStackView < FeatureTest
       type: :section,
       layout_file: template_path,
       params: {
-        start_page_number: 1,
         groups: [
           {
             details: [

--- a/test/features/section_report_stack_view_row_bottom_margin/test_section_report_stack_view_row_bottom_margin.rb
+++ b/test/features/section_report_stack_view_row_bottom_margin/test_section_report_stack_view_row_bottom_margin.rb
@@ -8,7 +8,6 @@ class TestSectionReportStackViewRowBottomMargin < FeatureTest
       type: :section,
       layout_file: template_path,
       params: {
-        start_page_number: 1,
         groups: [
           {
             headers: {

--- a/test/features/section_report_text_block_vertical_align/test_section_report_text_block_vertical_align.rb
+++ b/test/features/section_report_text_block_vertical_align/test_section_report_text_block_vertical_align.rb
@@ -8,7 +8,6 @@ class TestSectionReportTextBlockVerticalAlign < FeatureTest
       type: :section,
       layout_file: template_path,
       params: {
-        start_page_number: 1,
         groups: [
           {
             details: %i(top middle bottom).flat_map { |id|

--- a/test/features/stack_view/test_stack_view.rb
+++ b/test/features/stack_view/test_stack_view.rb
@@ -8,7 +8,6 @@ class TestStackView < FeatureTest
       type: :section,
       layout_file: template_path,
       params: {
-        start_page_number: 1,
         groups: [
           {
             headers: {


### PR DESCRIPTION
> bc8d89d remove incomplete feature for start_page_number parameter

`start_page_number` の実装は中途半端で使用していないので一旦削除する